### PR TITLE
Add operationName argument to query()/subscribe()

### DIFF
--- a/InomialClient.js
+++ b/InomialClient.js
@@ -113,10 +113,11 @@ class InomialClient {
      * the query is sent immediately; if the connection is not established then the
      * query is queued until the connection becomes available.
      */
-    query(queryString, variables) {
+    query(queryString, variables, operationName) {
         // The query we're going to send to the server.
         let query = {
             query: queryString,
+            operationName: operationName,
             variables: variables
         };
 
@@ -151,7 +152,7 @@ class InomialClient {
      * Note that if the websocket is not connected, the subscription may not be
      * created immediately.
      */
-    subscribe(queryString, variables, callback) {
+    subscribe(queryString, variables, callback, operationName) {
 
         if (callback == null)
             throw new Error("callback must not be null");
@@ -159,6 +160,7 @@ class InomialClient {
         // The query we're going to send to the server.
         let query = {
             query: queryString,
+            operationName: operationName,
             variables: variables
         };
 


### PR DESCRIPTION
Allow an operation name to be specified when submitting a query, mutation or subscription.

Test JS code for this enhancement:

  ```js
  #!/usr/bin/env node
  
  const HOSTNAME = "bryanmbp2.local";
  const STAGE = "dev";
  const ORIGIN = "OperationNameTest";
  const APIKEY = "<redacted>";
  
  const InomialClient = require("./InomialClient.js");
  
  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
  
  let client = InomialClient.connect(HOSTNAME, STAGE, ORIGIN, APIKEY);
  
  const queryStr = 
      "query getAccountUuidByUsn($usn: String!) {"
    + "  account(usn: $usn) {"
    + "    accountUuid"
    + "  }"
    + "}"
    + ""
    + "query getAccountUsnByUuid($accountUuid: UUID!) {"
    + "  account(uuid: $accountUuid) {"
    + "    usn"
    + "  }"
    + "}"
    + "";
  
  function onError(e)
  {
    console.error("Request failed: " + e);
  }
  
  function onSuccess(response)
  {
    console.log("Response: " + JSON.stringify(response));
  }
  
  console.log("Sending request for operation getAccountUuidByUsn.");
  client.query(queryStr, { usn: "2142420658" }, "getAccountUuidByUsn")
    .then(onSuccess, onError);
  
  console.log("Sending request for operation getAccountUsnByUuid.");
  client.query(queryStr, { accountUuid: "81c5155d-8140-4ff1-b9b6-60fad5cd05a8" },
       "getAccountUsnByUuid")
    .then(onSuccess, onError);
  ```

Output:

  ```
 $ ./OperationNameTest.js 
Attempting to connect to wss://bryanmbp2.local/dev/api/events
Sending request for operation getAccountUuidByUsn.
Sending request for operation getAccountUsnByUuid.
(node:9934) Warning: Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.
Connection started to wss://bryanmbp2.local/dev/api/events
Response: {"data":{"account":{"accountUuid":"81c5155d-8140-4ff1-b9b6-60fad5cd05a8"}},"errors":[],"extensions":{"requestId":"R1000000"}}
Response: {"data":{"account":{"usn":"2142420658"}},"errors":[],"extensions":{"requestId":"R1000001"}}
onClose, reason=1001
Auto-reconnection disabled
```