### PR TITLE
Ability to tweak TLS params. Adjustable log levels, including wire-level logging.

### DIFF
--- a/InomialClient.js
+++ b/InomialClient.js
@@ -267,7 +267,7 @@ class InomialClient {
       // Indent for readability
       console.group("[InomialClient] GraphQL request " + graphqlRequest.extensions.requestId + " sent:");
 
-      if (graphqlRequest.operationName && /[_A-Za-z]\w*/.test(graphqlRequest.operationName))
+      if (graphqlRequest.operationName && /^[_A-Za-z]\w*$/.test(graphqlRequest.operationName))
       {
         // If operation name was given and is well-formed, we'll try a quick-and-dirty regex search to locate the
         // query/mutation/subscription by that name in the query document and print it out as an excerpt (since the

--- a/InomialClient.js
+++ b/InomialClient.js
@@ -7,12 +7,19 @@
 // subscriptions.
 //
 
+// Log level constants
+const NONE = 0;     // No logging at all.
+const ERRORS = 1;   // Only print errors (e.g. connection dropouts).
+const INFO = 2;     // Also print informational messages (connection establishment).
+const FINE = 3;     // Also print wire-level logging of GraphQL requests/responses.
+
 module.exports = {
-    connect: function(hostname, stage, origin, apikey) {
-        const client = new InomialClient(hostname, stage, origin, apikey);
+    connect: function(hostname, stage, origin, apikey, websocketClientConfig, logLevel) {
+        const client = new InomialClient(hostname, stage, origin, apikey, websocketClientConfig, logLevel);
         client.connect();
         return client;
-    }
+    },
+    LogLevel: { NONE: NONE, ERRORS: ERRORS, INFO: INFO, FINE: FINE }
 };
 
 
@@ -33,13 +40,31 @@ class InomialClient {
     // Origin is nullable is the WSS Origin header; should be null for web clients, or
     // you can set it to let the server know what your application name is.
     //
+    // websocketClientConfig is an optional JS object passed-on verbatim to the WebSocketClient
+    // constructor; this can allow the caller to fine-tune socket/TLS parameters as needed.
+    // See <https://github.com/theturtle32/WebSocket-Node/blob/master/docs/WebSocketClient.md#client-config-options>
+    // for more details on what properties this object can accept.
     //
-    constructor(hostname, stage, origin, apikey)
+    // logLevel (if specified) should be one of the following constants:
+    //   LogLevel.NONE          No logging at all.
+    //   LogLevel.ERRORS        Only print errors (e.g. connection dropouts).
+    //   LogLevel.INFO          Also print informational messages (connection establishment).
+    //   LogLevel.FINE          Also print wire-level logging of GraphQL requests/responses.
+    // Default logging level is INFO if logLevel is null or omitted, but can be overridden with INOMIAL_LOG_LEVEL
+    // environment variable.
+    constructor(hostname, stage, origin, apikey, websocketClientConfig, logLevel)
     {
+        if (!hostname && !("INOMIAL_HOSTNAME" in process.env))
+          throw new Error("No hostname given (INOMIAL_HOSTNAME is unset)");
+        if (!stage && !("INOMIAL_STAGE" in process.env))
+          throw new Error("No stage given (INOMIAL_STAGE is unset)");
+
         hostname = hostname || process.env.INOMIAL_HOSTNAME;
         stage = stage || process.env.INOMIAL_STAGE;
         apikey = apikey || process.env.INOMIAL_APIKEY;
-        
+
+        this.clientConfig = websocketClientConfig;
+
         // If the connection is down, queries are added to this queue.
         // When the connection comes back up, the queries are executed.
         this.requestQueue = [];
@@ -68,20 +93,54 @@ class InomialClient {
         this.subscriptionUuidCache = {};
 
         this.reconnectPolicy = false;
+
+        if (logLevel != null)
+        {
+          this.logLevel = logLevel
+        }
+        else if ("INOMIAL_LOG_LEVEL" in process.env)
+        {
+          switch (process.env.INOMIAL_LOG_LEVEL.toUpperCase())
+          {
+            case "NONE":
+              this.logLevel = NONE;
+              break;
+            case "ERRORS":
+              this.logLevel = ERRORS;
+              break;
+            case "INFO":
+              this.logLevel = INFO;
+              break;
+            case "FINE":
+              this.logLevel = FINE;
+              break;
+            default:
+              this.logLevel = INFO;
+          }
+        }
+        else
+        {
+          this.logLevel = INFO;
+        }
+    }
+
+    setLogLevel(logLevel) {
+      this.logLevel = logLevel;
     }
 
 //
 // Connect to the WebSocket server. 
 //
     connect() {
-        console.log("Attempting to connect to " + this.url);
+        if (this.logLevel >= INFO)
+          console.info("[InomialClient] Attempting to connect to " + this.url);
 
         let headers;
 
         if (this.apikey != null)
             headers = {"Authorization": "BASIC " + this.apikey};
 
-        this.client = new WebSocketClient();
+        this.client = new WebSocketClient(this.clientConfig);
 
         this.client.on('connect', this.onConnect.bind(this));
         this.client.on('connectFailed', this.onConnectError.bind(this));
@@ -94,7 +153,8 @@ class InomialClient {
 // connection will now be executed.
 //
     onConnect(connection) {
-        console.log("Connection started to " + this.url);
+        if (this.logLevel >= INFO)
+          console.info("[InomialClient] Connection started to " + this.url);
 
         this.connection = connection;
         connection.on('message', this.onMessage.bind(this));
@@ -112,8 +172,11 @@ class InomialClient {
     }
 
     onConnectError(e) {
-        console.log("Unable to connect: " + e);
-        console.log("  Retrying in 10 seconds");
+        if (this.logLevel >= ERRORS)
+        {
+          console.error("[InomialClient] Unable to connect: " + e);
+          console.error("  Retrying in 10 seconds");
+        }
         setTimeout(this.connect.bind(this), 10000);
     }
 
@@ -125,6 +188,9 @@ class InomialClient {
      * query is queued until the connection becomes available.
      */
     async query(queryString, variables, operationName) {
+        if (queryString == null)
+          throw new Error("queryString must not be null");
+
         // The query we're going to send to the server.
         let query = {
             query: queryString,
@@ -194,6 +260,56 @@ class InomialClient {
         this.sendRequest(request);
     }
 
+    logWireRequest(graphqlRequest) {
+      if (this.logLevel < FINE)
+        return;
+
+      // Indent for readability
+      console.group("[InomialClient] GraphQL request " + graphqlRequest.extensions.requestId + " sent:");
+
+      if (graphqlRequest.query.length >= 500 && graphqlRequest.operationName)
+      {
+        // Abbreviate the query document if it's too long (when operation name given) so it doesn't flood the logs
+        // if the same large query document is used repeatedly with different operations.
+        console.log("query: " + JSON.stringify(graphqlRequest.query.slice(0, 72) + "…"));
+      }
+      else
+      {
+        // Print ad-hoc queries in their entirety
+        console.group("query:");
+        console.log(graphqlRequest.query);
+        console.groupEnd();
+      }
+
+      if (graphqlRequest.operationName)
+        console.log("operationName: " + graphqlRequest.operationName);
+
+      if (graphqlRequest.variables)
+      {
+        console.group("variables:");
+        // Will colour-code JSON pretty-print if stdout is a TTY in node.js.
+        console.dir(graphqlRequest.variables, { depth: null });
+        console.groupEnd();
+      }
+
+      console.groupEnd();
+    }
+
+    logWireResponse(graphqlResponse) {
+      if (this.logLevel < FINE)
+        return;
+
+      // Indent for readability
+      if ("extensions" in graphqlResponse && "requestId" in graphqlResponse.extensions)
+        console.group("[InomialClient] GraphQL response for request "
+            + graphqlResponse.extensions.requestId + " received:");
+      else
+        console.group("[InomialClient] GraphQL response received:");
+      // Will colour-code JSON pretty-print if stdout is a TTY in node.js.
+      console.dir(graphqlResponse, { depth: null });
+      console.groupEnd();
+    }
+
     /**
      * Send a request. The promise has already been set up, but we only assign a request ID
      * when we actually send the request, in case we want to re-transmit it later with a different
@@ -206,15 +322,18 @@ class InomialClient {
         let query = request.query;
         query.extensions = {requestId: requestId};
         this.connection.sendUTF(JSON.stringify(query));
+        this.logWireRequest(query);
     }
 
     onMessage(message) {
         if (message.type !== 'utf8') {
-            console.log("Recieved unexpected response type: " + message.type);
+            if (this.logLevel >= ERRORS)
+              console.error("[InomialClient] Recieved unexpected response type: " + message.type);
             return;
         }
 
         let response = JSON.parse(message.utf8Data);
+        this.logWireResponse(response);
         let requestId = response.extensions != null ? response.extensions.requestId : null;
 
         let request = this.responseQueue[requestId];
@@ -224,8 +343,11 @@ class InomialClient {
             if (!request.isSubscription)
               delete this.responseQueue[requestId];
             request.resolve(response);
-        } else
-            console.log("Received response to unknown request " + requestId + ", response=" + JSON.stringify(response));
+        } else {
+            if (this.logLevel >= ERRORS)
+              console.error("[InomialClient] Received response to unknown request " + requestId
+                + ", response=" + JSON.stringify(response));
+        }
     }
 
     /**
@@ -233,16 +355,19 @@ class InomialClient {
      */
     doReconnect() {
         if (!this.reconnectPolicy) {
-            console.log("Auto-reconnection disabled");
+            if (this.logLevel >= INFO)
+              console.info("[InomialClient] Auto-reconnection disabled");
             return;
         }
 
-        console.log("Attempting to reconnect");
+        if (this.logLevel >= INFO)
+          console.info("[InomialClient] Attempting to reconnect");
 
         this.connection = null;
         for (let requestId in this.responseQueue) {
             if (this.responseQueue.hasOwnProperty(requestId)) {
-                console.log("Re-queueing request " + requestId);
+                if (this.logLevel >= INFO)
+                  console.info("Re-queueing request " + requestId);
                 const request = this.responseQueue[requestId];
                 this.requestQueue.push(request)
             }
@@ -253,12 +378,14 @@ class InomialClient {
     }
 
     onError(error) {
-        console.log("onError, error=" + error);
+        if (this.logLevel >= ERRORS)
+          console.error("[InomialClient] onError, error=" + error);
         this.doReconnect();
     }
 
     onClose(reason) {
-        console.log("onClose, reason=" + reason);
+        if (this.logLevel >= INFO)
+          console.info("[InomialClient] onClose, reason=" + reason);
         this.doReconnect();
     }
 

--- a/README.md
+++ b/README.md
@@ -281,19 +281,24 @@ An example of the `FINE` level logging output could be:
 
   ```
   [InomialClient] GraphQL request R1000002 sent:
-    query: "mutation createAccount(\n    $address: AccountAddressInput\n    $contact: …"
+    query (excerpt):
+      mutation createSubscription($subscriptionInput: SubscriptionInput!) {
+        subscription(subscription: $subscriptionInput) {
+          subscriptionUuid
+        }
+      }
     operationName: createSubscription
     variables:
       {
         subscriptionInput: {
-          accountUuid: '4ecb52d4-5db6-4210-82fe-f989ed6f8c6b',
-          subscriptionUuid: '69d14e82-05a3-4fdd-9735-5cc58fca400c'
+          accountUuid: '458e37cf-38f3-4475-8e36-6eb4fb6a5888',
+          subscriptionUuid: '8b27a381-7057-4da9-b893-911ed3faa8e9'
         }
       }
   [InomialClient] GraphQL response for request R1000002 received:
     {
       data: {
-        subscription: { subscriptionUuid: '69d14e82-05a3-4fdd-9735-5cc58fca400c' }
+        subscription: { subscriptionUuid: '8b27a381-7057-4da9-b893-911ed3faa8e9' }
       },
       errors: [],
       extensions: { requestId: 'R1000002' }


### PR DESCRIPTION
I've added two more optional arguments to the `InomialClient` constructor.

# TLS fine-tuning

The fifth argument (`websocketClientConfig`) allows low-level socket/TLS parameters of the websocket connection to be fine-tuned. This argument if non-null should be a JS object; supported properties are documented [here](https://github.com/theturtle32/WebSocket-Node/blob/master/docs/WebSocketClient.md#client-config-options).

For example, supplying the below JS object for the `websocketClientConfig` argument:

  ```js
  {
    tlsOptions: {
      rejectUnauthorized: false
    }
  }
  ```

…will disable server TLS certificate validation (avoids having to set the `NODE_TLS_REJECT_UNAUTHORIZED` variable to `0` and the warning message from node.js it produces).

Alternatively supplying the following object for the `websocketClientConfig` argument:

  ```js
  {
    tlsOptions: {
      ca: /* Insert contents of X.509 custom root CA certificate in PEM format here as a string */
    }
  }
  ```

…will allow the server TLS certificate to be validated against that custom root CA certificate (even if it's not listed in the default trust store).

# Adjustable log levels

The sixth constructor argument `logLevel` can be set to one of the following four constants that are exported from this module:

* `LogLevel.NONE`:          No logging at all.
* `LogLevel.ERRORS`:        Only print errors (e.g. connection dropouts).
* `LogLevel.INFO`:          Also print informational messages (connection establishment).
* `LogLevel.FINE`:          Also print wire-level logging of GraphQL requests/responses.

Default logging level if `null` is supplied is INFO, but this is also influenced by the `INOMIAL_LOG_LEVEL` environment variable if set.

The FINE level will print each GraphQL request/response as they are sent/received. An example of the output from FINE logging:

   ```
  [InomialClient] GraphQL request R1000002 sent:
    query (excerpt):
      mutation createSubscription($subscriptionInput: SubscriptionInput!) {
        subscription(subscription: $subscriptionInput) {
          subscriptionUuid
        }
      }
    operationName: createSubscription
    variables:
      {
        subscriptionInput: {
          accountUuid: '458e37cf-38f3-4475-8e36-6eb4fb6a5888',
          subscriptionUuid: '8b27a381-7057-4da9-b893-911ed3faa8e9'
        }
      }
  [InomialClient] GraphQL response for request R1000002 received:
    {
      data: {
        subscription: { subscriptionUuid: '8b27a381-7057-4da9-b893-911ed3faa8e9' }
      },
      errors: [],
      extensions: { requestId: 'R1000002' }
    }
   ```

There's also now a `setLogLevel()` method to change the logging level on-the-fly.

# Changes to logging statements

For all the existing logging statements in InomialClient.js, I've prefixed them with the string `[InomialClient]` to make it clear where the source of the logging is coming from, e.g.:

  ```
  [InomialClient] Attempting to connect to wss://bryanmbp2.local/dev/api/events
  [InomialClient] Connection started to wss://bryanmbp2.local/dev/api/events
  ```

I've also classified each existing logging statement as belonging to either the ERRORS or INFO category. Given that this code is expected to run in the browser as well as node.js, using `console.error()` and `console.info()` functions would be more appropriate for sending log messages to these categories, as opposed to printing everything via `console.log()`.

The [WHATWG](https://console.spec.whatwg.org/#loglevel-severity) spec defines severity levels for each of these logging functions, and at least in Firefox/Chrome there are separate tabs in the Developer console for Errors/Info/Log (debugging) messages.

# Argument validation in InomialClient() constructor

I've also made InomialClient's constructor throw an exception if the `hostname` and `stage` arguments are `null` *and* the respective `INOMIAL_HOSTNAME` and `INOMIAL_STAGE` environment variables are also unset - in this case there's nothing that can be done here (unless the application wants to improvise defaults).

# Tidy up README.md

I've marked all the Javascript code snippets in the README as of `js` type so GitHub will correctly syntax highlight them. I've also run a spell checker over the README file, and amended it to include the above additions.
